### PR TITLE
Create entity to represent a review for time records

### DIFF
--- a/src/main/java/com/app/kowalski/task/Task.java
+++ b/src/main/java/com/app/kowalski/task/Task.java
@@ -2,9 +2,7 @@ package com.app.kowalski.task;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -12,11 +10,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import com.app.kowalski.activity.Activity;
-import com.app.kowalski.timerecord.TimeRecord;
 import com.app.kowalski.user.KowalskiUser;
 
 @Entity
@@ -40,9 +36,6 @@ public class Task {
 	@ManyToOne
     @JoinColumn(name="kowalskiuser_kUserId")
 	private KowalskiUser accountable;
-
-	@OneToMany
-    private List<TimeRecord> timeRecords = new ArrayList<TimeRecord>();
 
 	private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 
@@ -180,26 +173,4 @@ public class Task {
 		this.accountable = accountable;
 	}
 
-	/**
-	 * @return the timeRecords
-	 */
-	public List<TimeRecord> getTimeRecords() {
-		return timeRecords;
-	}
-
-	/**
-	 *
-	 * @param timeRecord
-	 */
-	public void addTimeRecord(TimeRecord timeRecord) {
-		this.timeRecords.add(timeRecord);
-	}
-
-	/**
-	 *
-	 * @param timeRecord
-	 */
-	public void removeTimeRecord(TimeRecord timeRecord) {
-		this.timeRecords.remove(timeRecord);
-	}
 }

--- a/src/main/java/com/app/kowalski/timerecord/TimeRecord.java
+++ b/src/main/java/com/app/kowalski/timerecord/TimeRecord.java
@@ -2,7 +2,9 @@ package com.app.kowalski.timerecord;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -11,9 +13,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import com.app.kowalski.task.Task;
+import com.app.kowalski.timerecordreview.TimeRecordReview;
 import com.app.kowalski.user.KowalskiUser;
 
 @Entity
@@ -24,11 +28,11 @@ public class TimeRecord {
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Integer trId;
 
-	@ManyToOne(cascade=CascadeType.ALL)
+	@ManyToOne
     @JoinColumn(name="kowalskiuser_kUserId")
     private KowalskiUser user;
 
-	@ManyToOne(cascade=CascadeType.ALL)
+	@ManyToOne
     @JoinColumn(name="task_taskId")
     private Task task;
 
@@ -36,6 +40,11 @@ public class TimeRecord {
 	private LocalDate reportedDay;
 	private LocalTime reportedTime;
 	private String comment;
+
+	private TimeRecordState state;
+
+	@OneToMany(cascade=CascadeType.ALL, orphanRemoval=true)
+	private List<TimeRecordReview> reviews = new ArrayList<TimeRecordReview>();
 
 	public TimeRecord() {}
 
@@ -46,6 +55,7 @@ public class TimeRecord {
 		this.reportedDay = reportedDay;
 		this.reportedTime = reportedTime;
 		this.comment = comment;
+		this.state = TimeRecordState.NEW;
 	}
 
 	public TimeRecord editTimeRecord(KowalskiUser user, Task task, LocalDate reportedDay, LocalTime reportedTime,
@@ -156,5 +166,34 @@ public class TimeRecord {
 	 */
 	public void setComment(String comment) {
 		this.comment = comment;
+	}
+
+	/**
+	 * @return the state
+	 */
+	public TimeRecordState getState() {
+		return state;
+	}
+
+	/**
+	 * @param state the state to set
+	 */
+	public void setState(TimeRecordState state) {
+		this.state = state;
+	}
+
+	/**
+	 * @return the reviews
+	 */
+	public List<TimeRecordReview> getReviews() {
+		return reviews;
+	}
+
+	/**
+	 *
+	 * @param review
+	 */
+	public void addReview(TimeRecordReview review) {
+		this.reviews.add(review);
 	}
 }

--- a/src/main/java/com/app/kowalski/timerecord/TimeRecordController.java
+++ b/src/main/java/com/app/kowalski/timerecord/TimeRecordController.java
@@ -1,5 +1,7 @@
 package com.app.kowalski.timerecord;
 
+import java.util.List;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +17,7 @@ import com.app.kowalski.exception.InvalidTimeRecordException;
 import com.app.kowalski.exception.KowalskiUserNotFoundException;
 import com.app.kowalski.exception.TaskNotFoundException;
 import com.app.kowalski.exception.TimeRecordNotFoundException;
+import com.app.kowalski.timerecordreview.TimeRecordReviewDTO;
 import com.app.kowalski.util.HateoasLinksBuilder;
 
 @RestController
@@ -80,6 +83,19 @@ public class TimeRecordController {
 		}
 
 		return new ResponseEntity<String>(HttpStatus.OK);
+	}
+
+	@RequestMapping(value = "/{trId}/reviews", method = RequestMethod.GET)
+	public ResponseEntity<List<TimeRecordReviewDTO>> getTimeRecordReviews(@PathVariable Integer trId) {
+		List<TimeRecordReviewDTO> reviews = null;
+
+		try {
+			reviews = this.trService.getTimeRecordReviews(trId);
+		} catch (TimeRecordNotFoundException e) {
+			return new ResponseEntity<List<TimeRecordReviewDTO>>(HttpStatus.NOT_FOUND);
+		}
+
+		return new ResponseEntity<List<TimeRecordReviewDTO>>(reviews, HttpStatus.OK);
 	}
 
 }

--- a/src/main/java/com/app/kowalski/timerecord/TimeRecordDTO.java
+++ b/src/main/java/com/app/kowalski/timerecord/TimeRecordDTO.java
@@ -24,6 +24,7 @@ public class TimeRecordDTO extends ResourceSupport implements Serializable {
 	private String reportedDay;
 	private String reportedTime;
 	private String comment;
+	private String state;
 
 	private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 	private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -32,13 +33,14 @@ public class TimeRecordDTO extends ResourceSupport implements Serializable {
 	public TimeRecordDTO() {}
 
 	public TimeRecordDTO(TimeRecord timeRecord) {
-		this.setTrId(timeRecord.getTrId());
+		this.trId = timeRecord.getTrId();
 		this.userId = timeRecord.getUser().getkUserId();
 		this.taskId = timeRecord.getTask().getTaskId();
 		this.createdDate = sdf.format(timeRecord.getCreateDate());
 		this.reportedDay = timeRecord.getReportedDay().format(dateFormatter);
 		this.reportedTime = timeRecord.getReportedTime().format(timeFormatter);
 		this.comment = timeRecord.getComment();
+		this.state = timeRecord.getState().toString();
 	}
 
 	public TimeRecordDTO(Integer userId, Integer taskId, String reportedDay, String reportedTime, String comment) {
@@ -145,6 +147,20 @@ public class TimeRecordDTO extends ResourceSupport implements Serializable {
 	 */
 	public void setComment(String comment) {
 		this.comment = comment;
+	}
+
+	/**
+	 * @return the state
+	 */
+	public String getState() {
+		return state;
+	}
+
+	/**
+	 * @param state the state to set
+	 */
+	public void setState(String state) {
+		this.state = state;
 	}
 
 }

--- a/src/main/java/com/app/kowalski/timerecord/TimeRecordService.java
+++ b/src/main/java/com/app/kowalski/timerecord/TimeRecordService.java
@@ -6,6 +6,7 @@ import com.app.kowalski.exception.InvalidTimeRecordException;
 import com.app.kowalski.exception.KowalskiUserNotFoundException;
 import com.app.kowalski.exception.TaskNotFoundException;
 import com.app.kowalski.exception.TimeRecordNotFoundException;
+import com.app.kowalski.timerecordreview.TimeRecordReviewDTO;
 
 /**
  * Interface to expose allowed methods related to time records.
@@ -89,4 +90,25 @@ public interface TimeRecordService {
 	 */
 	public List<TimeRecordDTO> getAllRecordsForTask(Integer taskId, String startDate, String endDate)
 			throws TaskNotFoundException, InvalidTimeRecordException;
+
+	/**
+	 * Returns all reviews associated to given time record
+	 * @param trId time record reference
+	 * @return List of reviews
+	 *
+	 * @throws TimeRecordNotFoundException No time record was found in the system
+	 */
+	public List<TimeRecordReviewDTO> getTimeRecordReviews(Integer trId) throws TimeRecordNotFoundException;
+
+	/**
+	 * Includes a new review for given time record
+	 * @param trId time record reference
+	 * @param trReviewDTO time record review data
+	 * @return time record review data
+	 *
+	 * @throws TimeRecordNotFoundException No time record was found in the system
+	 * @throws KowalskiUserNotFoundException No user was found in the system
+	 */
+	public TimeRecordReviewDTO addTimeRecordReview(Integer trId, TimeRecordReviewDTO trReviewDTO)
+			throws TimeRecordNotFoundException, KowalskiUserNotFoundException;
 }

--- a/src/main/java/com/app/kowalski/timerecord/TimeRecordState.java
+++ b/src/main/java/com/app/kowalski/timerecord/TimeRecordState.java
@@ -1,0 +1,8 @@
+package com.app.kowalski.timerecord;
+
+public enum TimeRecordState {
+	NEW,
+	PENDING,
+	APPROVED,
+	REJECTED;
+}

--- a/src/main/java/com/app/kowalski/timerecordreview/TimeRecordReview.java
+++ b/src/main/java/com/app/kowalski/timerecordreview/TimeRecordReview.java
@@ -1,0 +1,153 @@
+package com.app.kowalski.timerecordreview;
+
+import java.util.Date;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import com.app.kowalski.timerecord.TimeRecord;
+import com.app.kowalski.timerecord.TimeRecordState;
+import com.app.kowalski.user.KowalskiUser;
+
+@Entity
+@Table(name = "timerecordreview")
+public class TimeRecordReview {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Integer trReviewId;
+
+	private TimeRecordState previousState;
+	private TimeRecordState nextState;
+	private String comment;
+	private Date createdDate;
+
+	@ManyToOne
+    @JoinColumn(name="timerecord_trId")
+    private TimeRecord timeRecord;
+
+	@ManyToOne
+	@JoinColumn(name="kowalskiuser_kUserId")
+	private KowalskiUser reviewer;
+
+	public TimeRecordReview() {}
+
+	public TimeRecordReview(TimeRecordReviewDTO trReviewDTO, KowalskiUser reviewer) {
+		this.previousState =  TimeRecordState.valueOf(trReviewDTO.getPreviousState().toUpperCase());
+		this.nextState = TimeRecordState.valueOf(trReviewDTO.getNextState().toUpperCase());
+		this.comment = trReviewDTO.getComment();
+		this.createdDate = new Date();
+		this.reviewer = reviewer;
+	}
+
+	public TimeRecordReview(TimeRecordState nextState, String comment, KowalskiUser reviewer) {
+		//this.previousState = timeRecord.getState();
+		this.nextState = nextState;
+		this.comment = comment;
+		this.createdDate = new Date();
+		this.reviewer = reviewer;
+	}
+
+	/**
+	 * @return the trReviewId
+	 */
+	public Integer getTrReviewId() {
+		return trReviewId;
+	}
+
+	/**
+	 * @param trReviewId the trReviewId to set
+	 */
+	public void setTrReviewId(Integer trReviewId) {
+		this.trReviewId = trReviewId;
+	}
+
+	/**
+	 * @return the timeRecord
+	 */
+	public TimeRecord getTimeRecord() {
+		return timeRecord;
+	}
+
+	/**
+	 * @param timeRecord the timeRecord to set
+	 */
+	public void setTimeRecord(TimeRecord timeRecord) {
+		this.timeRecord = timeRecord;
+	}
+
+	/**
+	 * @return the previousState
+	 */
+	public TimeRecordState getPreviousState() {
+		return previousState;
+	}
+
+	/**
+	 * @param previousState the previousState to set
+	 */
+	public void setPreviousState(TimeRecordState previousState) {
+		this.previousState = previousState;
+	}
+
+	/**
+	 * @return the nextState
+	 */
+	public TimeRecordState getNextState() {
+		return nextState;
+	}
+
+	/**
+	 * @param nextState the nextState to set
+	 */
+	public void setNextState(TimeRecordState nextState) {
+		this.nextState = nextState;
+	}
+
+	/**
+	 * @return the comment
+	 */
+	public String getComment() {
+		return comment;
+	}
+
+	/**
+	 * @param comment the comment to set
+	 */
+	public void setComment(String comment) {
+		this.comment = comment;
+	}
+
+	/**
+	 * @return the createdDate
+	 */
+	public Date getCreatedDate() {
+		return createdDate;
+	}
+
+	/**
+	 * @param createdDate the createdDate to set
+	 */
+	public void setCreatedDate(Date createdDate) {
+		this.createdDate = createdDate;
+	}
+
+	/**
+	 * @return the reviewer
+	 */
+	public KowalskiUser getReviewer() {
+		return reviewer;
+	}
+
+	/**
+	 * @param reviewer the reviewer to set
+	 */
+	public void setReviewer(KowalskiUser reviewer) {
+		this.reviewer = reviewer;
+	}
+}

--- a/src/main/java/com/app/kowalski/timerecordreview/TimeRecordReviewDTO.java
+++ b/src/main/java/com/app/kowalski/timerecordreview/TimeRecordReviewDTO.java
@@ -1,0 +1,125 @@
+package com.app.kowalski.timerecordreview;
+
+import java.io.Serializable;
+
+import org.springframework.hateoas.ResourceSupport;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * Class used to expose time record review parameters through the REST API
+ * following the Data Transfer Object pattern.
+ */
+@SuppressWarnings("serial")
+@JsonInclude(Include.NON_NULL)
+public class TimeRecordReviewDTO extends ResourceSupport implements Serializable {
+
+	private Integer trReviewId;
+	private Integer trId;
+	private String previousState;
+	private String nextState;
+	private String comment;
+	private Integer reviewerId;
+
+	public TimeRecordReviewDTO() {}
+
+	public TimeRecordReviewDTO(TimeRecordReview trReview) {
+		this.trReviewId = trReview.getTrReviewId();
+		this.trId = trReview.getTimeRecord().getTrId();
+		this.previousState = trReview.getPreviousState().toString();
+		this.nextState = trReview.getNextState().toString();
+		this.comment = trReview.getComment();
+		this.reviewerId = trReview.getReviewer().getkUserId();
+	}
+
+	public TimeRecordReviewDTO(String nextState, String comment, Integer reviewerId) {
+		this.nextState = nextState;
+		this.comment = comment;
+		this.reviewerId = reviewerId;
+	}
+
+	/**
+	 * @return the trReviewId
+	 */
+	public Integer getTrReviewId() {
+		return trReviewId;
+	}
+
+	/**
+	 * @param trReviewId the trReviewId to set
+	 */
+	public void setTrReviewId(Integer trReviewId) {
+		this.trReviewId = trReviewId;
+	}
+
+	/**
+	 * @return the trId
+	 */
+	public Integer getTrId() {
+		return trId;
+	}
+
+	/**
+	 * @param trId the trId to set
+	 */
+	public void setTrId(Integer trId) {
+		this.trId = trId;
+	}
+
+	/**
+	 * @return the previousState
+	 */
+	public String getPreviousState() {
+		return previousState;
+	}
+
+	/**
+	 * @param previousState the previousState to set
+	 */
+	public void setPreviousState(String previousState) {
+		this.previousState = previousState;
+	}
+
+	/**
+	 * @return the nextState
+	 */
+	public String getNextState() {
+		return nextState;
+	}
+
+	/**
+	 * @param nextState the nextState to set
+	 */
+	public void setNextState(String nextState) {
+		this.nextState = nextState;
+	}
+
+	/**
+	 * @return the comment
+	 */
+	public String getComment() {
+		return comment;
+	}
+
+	/**
+	 * @param comment the comment to set
+	 */
+	public void setComment(String comment) {
+		this.comment = comment;
+	}
+
+	/**
+	 * @return the reviewerId
+	 */
+	public Integer getReviewerId() {
+		return reviewerId;
+	}
+
+	/**
+	 * @param reviewerId the reviewerId to set
+	 */
+	public void setReviewerId(Integer reviewerId) {
+		this.reviewerId = reviewerId;
+	}
+}

--- a/src/main/java/com/app/kowalski/timerecordreview/TimeRecordReviewRepository.java
+++ b/src/main/java/com/app/kowalski/timerecordreview/TimeRecordReviewRepository.java
@@ -1,0 +1,5 @@
+package com.app.kowalski.timerecordreview;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TimeRecordReviewRepository extends JpaRepository<TimeRecordReview, Integer> {}

--- a/src/main/java/com/app/kowalski/user/KowalskiUser.java
+++ b/src/main/java/com/app/kowalski/user/KowalskiUser.java
@@ -1,9 +1,7 @@
 package com.app.kowalski.user;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import javax.persistence.Entity;
@@ -11,12 +9,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import com.app.kowalski.activity.Activity;
 import com.app.kowalski.project.Project;
-import com.app.kowalski.timerecord.TimeRecord;
 
 @Entity
 @Table(name = "kowalskiuser")
@@ -37,9 +33,6 @@ public class KowalskiUser {
 
 	@ManyToMany(mappedBy = "members")
     private Set<Activity> activities = new HashSet<>();
-
-	@OneToMany
-    private List<TimeRecord> timeRecords = new ArrayList<TimeRecord>();
 
 	public KowalskiUser() {}
 
@@ -157,26 +150,4 @@ public class KowalskiUser {
 		return this.activities;
 	}
 
-	/**
-	 * @return the timeRecords
-	 */
-	public List<TimeRecord> getTimeRecords() {
-		return timeRecords;
-	}
-
-	/**
-	 *
-	 * @param timeRecord
-	 */
-	public void addTimeRecord(TimeRecord timeRecord) {
-		this.timeRecords.add(timeRecord);
-	}
-
-	/**
-	 *
-	 * @param timeRecord
-	 */
-	public void removeTimeRecord(TimeRecord timeRecord) {
-		this.timeRecords.remove(timeRecord);
-	}
 }

--- a/src/main/java/com/app/kowalski/util/ProjectLoader.java
+++ b/src/main/java/com/app/kowalski/util/ProjectLoader.java
@@ -12,12 +12,14 @@ import com.app.kowalski.exception.InvalidTimeRecordException;
 import com.app.kowalski.exception.KowalskiUserNotFoundException;
 import com.app.kowalski.exception.ProjectNotFoundException;
 import com.app.kowalski.exception.TaskNotFoundException;
+import com.app.kowalski.exception.TimeRecordNotFoundException;
 import com.app.kowalski.project.ProjectDTO;
 import com.app.kowalski.project.ProjectService;
 import com.app.kowalski.task.TaskDTO;
 import com.app.kowalski.task.TaskService;
 import com.app.kowalski.timerecord.TimeRecordDTO;
 import com.app.kowalski.timerecord.TimeRecordService;
+import com.app.kowalski.timerecordreview.TimeRecordReviewDTO;
 import com.app.kowalski.user.KowalskiUserDTO;
 import com.app.kowalski.user.KowalskiUserService;
 
@@ -149,6 +151,21 @@ public class ProjectLoader implements ApplicationListener<ContextRefreshedEvent>
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
+
+		/*******************************************************************************
+		 * Time record reviews
+		 *******************************************************************************/
+		TimeRecordReviewDTO trReview1 = new TimeRecordReviewDTO("approved", "Sem comentarios", k4.getkUserId());
+		TimeRecordReviewDTO trReview2 = new TimeRecordReviewDTO("rejected", "Apontamento invalido", k4.getkUserId());
+
+		try {
+			trReview1 = trService.addTimeRecordReview(tr1.getTrId(), trReview1);
+			trReview2 = trService.addTimeRecordReview(tr2.getTrId(), trReview2);
+		} catch (TimeRecordNotFoundException | KowalskiUserNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+
 	}
 
 }


### PR DESCRIPTION
Once the user creates a new time record, it can be reviewed by one or
more users. A basic entity was created to register these transactions,
but the workflow to correlate the states still must be implemented.