### PR TITLE
Fix run command on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There is no official release of KowalskiProject yet. Currently, the project is u
 
 ```
 $ cd kowalski
-$ mvn spring-boot:run
+$ gradlew bootRun
 ```
 
 The REST API documentation is provided through Swagger - available at *http://localhost:5000/swagger-ui.html*


### PR DESCRIPTION
Hi guys, please review.

The project's build tool has been moved from maven to gradle.